### PR TITLE
Cache manager

### DIFF
--- a/src/component/app.rs
+++ b/src/component/app.rs
@@ -34,7 +34,7 @@ use crate::{
 use super::{
     cache_manager_dialog::CacheManagerDialogMsg,
     connection_list::ConnectionListModel,
-    messages::messages_page::{MessagesPageModel, MessagesPageMsg},
+    messages::messages_page::{MessagesPageModel, MessagesPageMsg, MESSAGES_PAGE_BROKER},
     settings_dialog::SettingsDialogModel,
     topics::topics_page::TopicsPageModel,
 };
@@ -280,7 +280,7 @@ impl Component for AppModel {
 
         let messages_page: Controller<MessagesPageModel> = MessagesPageModel::builder()
             .priority(glib::Priority::HIGH_IDLE)
-            .launch(())
+            .launch_with_broker((), &MESSAGES_PAGE_BROKER)
             .detach();
 
         let settings_dialog: Controller<SettingsDialogModel> = SettingsDialogModel::builder()

--- a/src/component/messages/messages_tab.rs
+++ b/src/component/messages/messages_tab.rs
@@ -116,6 +116,7 @@ pub enum MessagesTabMsg {
     ResendMessages(Copy),
     AddMessages,
     SetCacheOrder(Option<String>, String),
+    RefreshTopic,
 }
 
 #[derive(Debug)]
@@ -941,6 +942,22 @@ impl FactoryComponent for MessagesTabModel {
                 widgets.cache_timestamp.set_text("");
                 widgets.btn_cache_toggle.set_active(false);
                 sender.input(MessagesTabMsg::ToggleMode(false));
+            }
+            MessagesTabMsg::RefreshTopic => {
+                let conn = self.connection.clone().unwrap();
+                let topic = self.topic.clone().unwrap();
+                let result_topic = Repository::new().find_topic(conn.id.unwrap(), &topic.name);
+                match result_topic {
+                    Some(topic) => {
+                        self.topic = Some(topic.clone());
+                        if topic.cached.is_none() {
+                            widgets.cache_timestamp.set_text("");
+                            widgets.btn_cache_toggle.set_active(false);
+                            sender.input(MessagesTabMsg::ToggleMode(false));
+                        }
+                    }
+                    None => warn!("unable to refresh topic after cache destroyed"),
+                };
             }
             MessagesTabMsg::RefreshTotalCounter => {
                 info!("refreshing total counter");


### PR DESCRIPTION
  - Fixes #27: when destroying a topic cache with the topic tab open, refreshes the tab.