### PR TITLE
Cache configurations.

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -58,7 +58,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         with:
           prerelease: false
-          draft: false
+          draft: true 
           generate_release_notes: true
           append_body: true
           files: |

--- a/src/backend/kafka.rs
+++ b/src/backend/kafka.rs
@@ -800,6 +800,20 @@ impl KafkaBackend {
                                 info!("consumer-{}::done::{}", worker_id, local);
                                 break;
                             }
+                        } else {
+                            let local = local_counter.load(Ordering::SeqCst);
+                            let global = mcounter.load(Ordering::SeqCst);
+                            trace!(
+                                "consumer-{}::larger_offset::[partition={}, offset={}/{}, local={}, global={}]",
+                                worker_id, current_partition, current_offset, max_offset, local, global
+                            );
+                            if global >= total {
+                                debug!(
+                                    "consumer-{}::done(larger_offset)::[partition={}, offset={}/{}, local={}, global={}]",
+                                    worker_id, current_partition, current_offset, max_offset, local, global
+                                );
+                                break;
+                            }
                         }
                     }
                 },

--- a/src/component/cache_manager_dialog.rs
+++ b/src/component/cache_manager_dialog.rs
@@ -414,9 +414,9 @@ impl Component for CacheManagerDialogModel {
                             cache_size_formatted,
                         );
                     }
-                    root.queue_allocate();
-                    root.present(parent);
                 }
+                root.queue_allocate();
+                root.present(parent);
             }
             CacheManagerDialogMsg::DeleteTopicCache {
                 connection_id,
@@ -434,6 +434,7 @@ impl Component for CacheManagerDialogModel {
                     let maybe_topic = worker.cleanup_messages(&MessagesCleanupRequest {
                         connection_id,
                         topic_name,
+                        refresh: true,
                     });
                     if let Some(_topic) = maybe_topic {
                         self.topics_wrapper.remove(idx);

--- a/src/component/cache_manager_dialog.rs
+++ b/src/component/cache_manager_dialog.rs
@@ -1,6 +1,6 @@
 use adw::prelude::*;
 use fs_extra::dir::get_size;
-use gtk::glib::SignalHandlerId;
+use gtk::{glib::SignalHandlerId, ColumnViewColumn};
 use humansize::{format_size, DECIMAL};
 use std::{cell::RefCell, cmp::Ordering, fs, path::Path};
 use sysinfo::Disks;
@@ -265,6 +265,7 @@ pub enum CacheManagerDialogMsg {
         connection_id: usize,
         topic_name: String,
     },
+    Refresh,
 }
 
 pub struct CacheManagerDialogInit {}
@@ -282,7 +283,20 @@ impl Component for CacheManagerDialogModel {
             set_title: "Cache Manager",
             #[wrap(Some)]
             set_child = &gtk::Box {
-                adw::HeaderBar {},
+                adw::HeaderBar {
+                    pack_end = &gtk::Box {
+                        set_orientation: gtk::Orientation::Horizontal,
+                        gtk::Button {
+                            set_tooltip_text: Some("Refresh disk/cache usage"),
+                            set_icon_name: "media-playlist-repeat-symbolic",
+                            set_margin_end: 5,
+                            add_css_class: "circular",
+                            connect_clicked[sender] => move |_| {
+                                sender.input(CacheManagerDialogMsg::Refresh);
+                            },
+                        }
+                    },
+                },
                 set_valign: gtk::Align::Fill,
                 set_orientation: gtk::Orientation::Vertical,
                 gtk::Box {
@@ -352,7 +366,7 @@ impl Component for CacheManagerDialogModel {
     fn init(
         _init: Self::Init,
         root: Self::Root,
-        _sender: ComponentSender<Self>,
+        sender: ComponentSender<Self>,
     ) -> ComponentParts<Self> {
         let settings = Settings::read().unwrap_or_default();
         // Initialize the ListView wrapper
@@ -360,6 +374,15 @@ impl Component for CacheManagerDialogModel {
         view_wrapper.append_column::<DiskUsageColumn>();
         view_wrapper.append_column::<ConnectionColumn>();
         view_wrapper.append_column::<TopicColumn>();
+        let sort_column: Option<&ColumnViewColumn> =
+            view_wrapper.get_columns().get(DiskUsageColumn::COLUMN_NAME);
+        let sort_type = gtk::SortType::Descending;
+        info!(
+            "sort_column::{:?}, sort_type::{:?}",
+            sort_column.map(|c| c.title()),
+            sort_type
+        );
+        view_wrapper.view.sort_by_column(sort_column, sort_type);
 
         let model = CacheManagerDialogModel {
             cache_dir: settings.cache_dir,
@@ -380,6 +403,11 @@ impl Component for CacheManagerDialogModel {
         match message {
             CacheManagerDialogMsg::Show => {
                 let parent = &relm4::main_application().active_window().unwrap();
+                sender.input(CacheManagerDialogMsg::Refresh);
+                root.queue_allocate();
+                root.present(parent);
+            }
+            CacheManagerDialogMsg::Refresh => {
                 self.topics_wrapper.clear();
                 let mut disks = Disks::new_with_refreshed_list();
                 let settings = Settings::read().unwrap_or_default();
@@ -415,8 +443,6 @@ impl Component for CacheManagerDialogModel {
                         );
                     }
                 }
-                root.queue_allocate();
-                root.present(parent);
             }
             CacheManagerDialogMsg::DeleteTopicCache {
                 connection_id,

--- a/src/component/messages/messages_cache_settings_dialog.rs
+++ b/src/component/messages/messages_cache_settings_dialog.rs
@@ -1,0 +1,557 @@
+use core::f64;
+use std::str::FromStr;
+
+use adw::{prelude::*, AlertDialog};
+use chrono::{Datelike, Local, NaiveDateTime, TimeZone, Timelike, Utc};
+use chrono_tz::America;
+use copypasta::{ClipboardContext, ClipboardProvider};
+use gtk::Adjustment;
+use relm4::*;
+use relm4_components::simple_adw_combo_row::SimpleComboRow;
+use tracing::*;
+use uuid::Uuid;
+
+use crate::backend::kafka::{KafkaBackend, KafkaFetch};
+use crate::backend::repository::{FetchMode, KrustConnection, KrustTopic, KrustTopicCache};
+use crate::backend::worker::{MessagesCleanupRequest, MessagesWorker};
+use crate::component::messages::messages_tab::AVAILABLE_PAGE_SIZES;
+use crate::modals::utils::build_confirmation_alert;
+use crate::{AppMsg, Repository, DATE_TIME_FORMAT, TOASTER_BROKER};
+
+const DEFAULT_MESSAGES_PER_PARTITION: usize = 10000;
+
+pub struct MessagesCacheSettingsDialogModel {
+    pub connection: KrustConnection,
+    pub topic: KrustTopic,
+    pub default_page_size_combo: Controller<SimpleComboRow<u16>>,
+    pub selected_fetch_mode: Option<FetchMode>,
+    pub selected_default_page_size: Option<u16>,
+    pub confirmation_alert: AlertDialog,
+    pub clipboard: Box<dyn ClipboardProvider>,
+}
+
+#[derive(Debug)]
+pub enum MessagesCacheSettingsDialogMsg {
+    Show,
+    DefaultPageSizeSelected(usize),
+    FetchModeSelected(FetchMode),
+    ApplySettings,
+    ConfirmApplySettings,
+    Ignore,
+    RefreshTopicMessagesCounter,
+    CopyToClipboard(String),
+}
+
+#[derive(Debug)]
+pub enum MessagesCacheSettingsDialogOutput {
+    Update(KrustTopicCache),
+}
+
+#[derive(Debug)]
+pub enum AsyncCommandOutput {
+    RefreshTopicMessagesCounter(KrustTopic),
+}
+
+#[relm4::component(pub)]
+impl Component for MessagesCacheSettingsDialogModel {
+    type Init = (KrustConnection, KrustTopic);
+    type Input = MessagesCacheSettingsDialogMsg;
+    type Output = MessagesCacheSettingsDialogOutput;
+    type CommandOutput = AsyncCommandOutput;
+
+    view! {
+        #[root]
+        main_dialog = adw::Dialog {
+            set_title: "Cache",
+            set_content_width: 730,
+            set_content_height: 350,
+            #[wrap(Some)]
+            set_child = &gtk::Box {
+                set_orientation: gtk::Orientation::Vertical,
+                adw::HeaderBar {},
+                set_valign: gtk::Align::Fill,
+                gtk::Box {
+                    set_orientation: gtk::Orientation::Vertical,
+                    set_valign: gtk::Align::Fill,
+                    set_margin_all: 10,
+                    adw::PreferencesGroup {
+                        set_title: "Status",
+                        #[name(status_topic_name)]
+                        adw::ActionRow {
+                            set_subtitle: "Topic name",
+                            add_suffix = &gtk::Box {
+                                set_orientation: gtk::Orientation::Horizontal,
+                                gtk::Button {
+                                    set_tooltip_text: Some("Copy value to clipboard"),
+                                    set_icon_name: "edit-copy-symbolic",
+                                    set_margin_start: 5,
+                                    set_valign: gtk::Align::Center,
+                                    connect_clicked[sender,status_topic_name] => move |_| {
+                                        let text = status_topic_name.title().to_string();
+                                        sender.input(MessagesCacheSettingsDialogMsg::CopyToClipboard(text));
+                                    },
+                                },
+                            },
+                        },
+                        #[name(status_topic_partitions)]
+                        adw::ActionRow {
+                            set_subtitle: "Topic partitions",
+                            add_suffix = &gtk::Box {
+                                set_orientation: gtk::Orientation::Horizontal,
+                                gtk::Button {
+                                    set_tooltip_text: Some("Refresh value"),
+                                    set_icon_name: "media-playlist-repeat-symbolic",
+                                    set_margin_start: 5,
+                                    set_valign: gtk::Align::Center,
+                                    connect_clicked[sender] => move |_| {
+                                        sender.input(MessagesCacheSettingsDialogMsg::RefreshTopicMessagesCounter);
+                                    },
+                                },
+                                gtk::Button {
+                                    set_tooltip_text: Some("Copy value to clipboard"),
+                                    set_icon_name: "edit-copy-symbolic",
+                                    set_margin_start: 5,
+                                    set_valign: gtk::Align::Center,
+                                    connect_clicked[sender,status_topic_partitions] => move |_| {
+                                        let text = status_topic_partitions.title().to_string();
+                                        sender.input(MessagesCacheSettingsDialogMsg::CopyToClipboard(text));
+                                    },
+                                },
+                            },
+                        },
+                        #[name(status_topic_messages_count)]
+                        adw::ActionRow {
+                            set_subtitle: "Topic messages count",
+                            add_suffix = &gtk::Box {
+                                set_orientation: gtk::Orientation::Horizontal,
+                                gtk::Button {
+                                    set_tooltip_text: Some("Refresh value"),
+                                    set_icon_name: "media-playlist-repeat-symbolic",
+                                    set_margin_start: 5,
+                                    set_valign: gtk::Align::Center,
+                                    connect_clicked[sender] => move |_| {
+                                        sender.input(MessagesCacheSettingsDialogMsg::RefreshTopicMessagesCounter);
+                                    },
+                                },
+                                gtk::Button {
+                                    set_tooltip_text: Some("Copy value to clipboard"),
+                                    set_icon_name: "edit-copy-symbolic",
+                                    set_margin_start: 5,
+                                    set_valign: gtk::Align::Center,
+                                    connect_clicked[sender,status_topic_messages_count] => move |_| {
+                                        let text = status_topic_messages_count.title().to_string();
+                                        sender.input(MessagesCacheSettingsDialogMsg::CopyToClipboard(text));
+                                    },
+                                },
+                            },
+                        },
+                    },
+                    adw::PreferencesGroup {
+                        set_title: "Settings",
+                        #[local_ref]
+                        default_page_size_combo -> adw::ComboRow {
+                            set_title: "Default page size",
+                            set_subtitle: "Set default page size for cache pagination",
+                            set_visible: true,
+                        },
+                        adw::ActionRow {
+                            set_title: "Fetch mode",
+                            set_css_classes: &["fetch-mode"],
+                            add_suffix = &gtk::StackSwitcher {
+                                set_overflow: gtk::Overflow::Hidden,
+                                set_orientation: gtk::Orientation::Horizontal,
+                                set_stack: Some(&fetch_mode_stack),
+                                set_hexpand: true,
+                                set_vexpand: true,
+                                set_valign: gtk::Align::Fill,
+                                set_halign: gtk::Align::Fill,
+                            },
+                        },
+
+                        #[name(fetch_mode_stack)]
+                        gtk::Stack {
+                            set_hhomogeneous: true,
+                            add_child = &gtk::Box {
+                                set_halign: gtk::Align::Fill,
+                                set_hexpand: true,
+                                set_orientation: gtk::Orientation::Vertical,
+                                gtk::Label {
+                                    set_label: "All messages",
+                                    set_halign: gtk::Align::Start,
+                                    set_margin_top: 8,
+                                    set_margin_start: 10,
+                                },
+                            } -> {
+                                set_title: FetchMode::All.to_string().as_str(),
+                                set_name: FetchMode::All.to_string().as_str(),
+                            },
+                            add_child: first_n_messages = &adw::SpinRow {
+                                    set_title: "Messages per partition",
+                                    set_subtitle: "First (n) messages per partitions",
+                                    set_valign: gtk::Align::Start,
+                                    set_numeric: true,
+                                    set_update_policy: gtk::SpinButtonUpdatePolicy::IfValid,
+                                    set_adjustment = Some(&offset_adjustment),
+                            } -> {
+                                set_title: FetchMode::Head.to_string().as_str(),
+                                set_name: FetchMode::Head.to_string().as_str(),
+                            },
+                            add_child: last_n_messages = &adw::SpinRow {
+                                    set_title: "Messages per partition",
+                                    set_subtitle: "Last (n) messages per partitions",
+                                    set_valign: gtk::Align::Start,
+                                    set_numeric: true,
+                                    set_update_policy: gtk::SpinButtonUpdatePolicy::IfValid,
+                                    set_adjustment = Some(&offset_adjustment),
+                            } -> {
+                                set_title: FetchMode::Tail.to_string().as_str(),
+                                set_name: FetchMode::Tail.to_string().as_str(),
+                            },
+                            add_child: timestamp_widget = &adw::ActionRow {
+                                    set_title: "From offset date/time",
+                                    set_valign: gtk::Align::Start,
+                                    set_margin_top: 4,
+                                    add_suffix: timestamp_container = &gtk::Box {
+                                        set_orientation: gtk::Orientation::Horizontal,
+                                        #[name(formatted_date)]
+                                        gtk::Entry {
+                                            set_valign: gtk::Align::Center,
+                                            set_editable: false,
+                                            set_max_width_chars: 10,
+                                        },
+                                        gtk::MenuButton {
+                                            set_tooltip_text: Some("Show calendar"),
+                                            set_valign: gtk::Align::Center,
+                                            set_direction: gtk::ArrowType::Down,
+                                            add_css_class: "flat",
+                                            set_margin_end: 5,
+                                            #[wrap(Some)]
+                                            set_popover: calendar_popover = &gtk::Popover {
+                                                set_position: gtk::PositionType::Bottom,
+                                                #[wrap(Some)]
+                                                set_child: calendar = &gtk::Calendar {
+                                                    connect_day_selected[formatted_date] => move |calendar| {
+                                                        let date = calendar.date();
+                                                        let year = date.year();
+                                                        let month = date.month();
+                                                        let day = date.day_of_month();
+                                                        let date_fmt = format!("{:02}/{:02}/{}", day, month, year);
+                                                        formatted_date.set_text(date_fmt.as_str());
+                                                    },
+                                                },
+                                            },
+                                        },
+                                        #[name(time_hours)]
+                                        gtk::SpinButton {
+                                            set_xalign: 0.5,
+                                            set_orientation: gtk::Orientation::Vertical,
+                                            set_wrap: true,
+                                            set_numeric: true,
+                                            set_update_policy: gtk::SpinButtonUpdatePolicy::IfValid,
+                                            set_increments: (1.0, 1.0),
+                                            set_range: (0.0, 23.0),
+                                            set_digits: 0,
+                                        },
+                                        gtk::Label { set_label: ":", set_margin_start: 2, set_margin_end: 2, },
+                                        #[name(time_minutes)]
+                                        gtk::SpinButton {
+                                            set_xalign: 0.5,
+                                            set_orientation: gtk::Orientation::Vertical,
+                                            set_wrap: true,
+                                            set_numeric: true,
+                                            set_update_policy: gtk::SpinButtonUpdatePolicy::IfValid,
+                                            set_increments: (1.0, 1.0),
+                                            set_range: (0.0, 59.0),
+                                            set_digits: 0,
+                                        },
+                                        gtk::Label { set_label: ":", set_margin_start: 2, set_margin_end: 2, },
+                                        #[name(time_seconds)]
+                                        gtk::SpinButton {
+                                            set_xalign: 0.5,
+                                            set_orientation: gtk::Orientation::Vertical,
+                                            set_wrap: true,
+                                            set_numeric: true,
+                                            set_update_policy: gtk::SpinButtonUpdatePolicy::IfValid,
+                                            set_increments: (1.0, 1.0),
+                                            set_range: (0.0, 59.0),
+                                            set_digits: 0,
+                                        },
+                                    },
+                            } -> {
+                                set_title: FetchMode::FromTimestamp.to_string().as_str(),
+                                set_name: FetchMode::FromTimestamp.to_string().as_str(),
+                            },
+                            connect_visible_child_name_notify[sender] => move |stack| {
+                                let selected = stack.visible_child_name();
+                                if let Some(selected) = selected {
+                                    let fetch_mode = FetchMode::from_str(selected.to_string().as_str());
+                                    sender.input(MessagesCacheSettingsDialogMsg::FetchModeSelected(fetch_mode.unwrap_or_default()));
+                                };
+                            },
+                        },
+                        gtk::Button {
+                            set_label: "Apply",
+                            add_css_class: "suggested-action",
+                            set_margin_top: 4,
+                            connect_clicked => MessagesCacheSettingsDialogMsg::ApplySettings,
+                        },
+                    }
+                }
+            }
+        }
+    }
+
+    fn init(
+        current_connection: Self::Init,
+        root: Self::Root,
+        sender: ComponentSender<Self>,
+    ) -> ComponentParts<Self> {
+        let (connection, topic) = current_connection.clone();
+        let default_idx = 0;
+
+        let default_page_size_combo = SimpleComboRow::builder()
+            .launch(SimpleComboRow {
+                variants: AVAILABLE_PAGE_SIZES.to_vec(),
+                active_index: Some(default_idx),
+            })
+            .forward(
+                sender.input_sender(),
+                MessagesCacheSettingsDialogMsg::DefaultPageSizeSelected,
+            );
+        let confirmation_alert = build_confirmation_alert(
+            "Apply".to_string(),
+            "Are you sure you want to delete the topic cache and apply the new settings?"
+                .to_string(),
+        );
+        let snd: ComponentSender<MessagesCacheSettingsDialogModel> = sender.clone();
+        confirmation_alert.connect_response(Some("cancel"), move |_, _| {
+            snd.input(MessagesCacheSettingsDialogMsg::Ignore);
+        });
+        let snd: ComponentSender<MessagesCacheSettingsDialogModel> = sender.clone();
+        confirmation_alert.connect_response(Some("confirm"), move |_, _| {
+            snd.input(MessagesCacheSettingsDialogMsg::ConfirmApplySettings);
+        });
+        let clipboard = Box::new(ClipboardContext::new().unwrap());
+        info!("init::[connection={:?}, topic={:?}]", &connection, &topic);
+        let model = MessagesCacheSettingsDialogModel {
+            connection,
+            topic,
+            default_page_size_combo,
+            selected_fetch_mode: None,
+            selected_default_page_size: None,
+            confirmation_alert,
+            clipboard,
+        };
+        let default_page_size_combo = model.default_page_size_combo.widget();
+        let offset_adjustment = Adjustment::builder()
+            .lower(1.0)
+            .upper(i32::MAX as f64)
+            .page_size(1000.0)
+            .step_increment(1.0)
+            .value(DEFAULT_MESSAGES_PER_PARTITION as f64)
+            .build();
+        let widgets = view_output!();
+        ComponentParts { model, widgets }
+    }
+
+    fn update_with_view(
+        &mut self,
+        widgets: &mut Self::Widgets,
+        msg: MessagesCacheSettingsDialogMsg,
+        sender: ComponentSender<Self>,
+        root: &Self::Root,
+    ) {
+        debug!("received message: {:?}", msg);
+
+        match msg {
+            MessagesCacheSettingsDialogMsg::Show => {
+                let connection = self.connection.clone();
+                let conn_id = connection.id.unwrap();
+                let mut repository = Repository::new();
+
+                widgets.status_topic_name.set_title(&self.topic.name);
+
+                let cached = repository.find_topic_cache(conn_id, &self.topic.name);
+
+                let default_page_size_idx = cached
+                    .clone()
+                    .map(|c| c.default_page_size as u32)
+                    .unwrap_or_default();
+                let fetch_mode = cached.clone().map(|c| c.fetch_mode).unwrap_or_default();
+                let fetch_value = cached
+                    .clone()
+                    .and_then(|c| c.fetch_value)
+                    .unwrap_or_default();
+                info!(
+                    "settings fetch mode {}, with default page size index::{}",
+                    fetch_mode.to_string(),
+                    default_page_size_idx
+                );
+
+                match fetch_mode {
+                    FetchMode::Head => {
+                        widgets.first_n_messages.set_value(fetch_value as f64);
+                    }
+                    FetchMode::Tail => {
+                        widgets.last_n_messages.set_value(fetch_value as f64);
+                    }
+                    FetchMode::All => (),
+                    FetchMode::FromTimestamp => {
+                        let date_time = Utc
+                            .timestamp_millis_opt(fetch_value)
+                            .unwrap()
+                            .with_timezone(&America::Sao_Paulo);
+                        let day = date_time.day();
+                        let month = date_time.month();
+                        let year = date_time.year();
+                        widgets.calendar.set_day(day as i32);
+                        widgets.calendar.set_month(month as i32);
+                        widgets.calendar.set_year(year);
+                        let hours = date_time.hour();
+                        let minutes = date_time.minute();
+                        let seconds = date_time.second();
+                        widgets.time_hours.set_value(hours as f64);
+                        widgets.time_minutes.set_value(minutes as f64);
+                        widgets.time_seconds.set_value(seconds as f64);
+                    }
+                };
+                widgets
+                    .default_page_size_combo
+                    .set_selected(default_page_size_idx);
+                widgets
+                    .fetch_mode_stack
+                    .set_visible_child_name(&fetch_mode.to_string());
+                sender.input(MessagesCacheSettingsDialogMsg::RefreshTopicMessagesCounter);
+
+                let parent = &relm4::main_application().active_window().unwrap();
+                root.queue_allocate();
+                root.present(parent);
+            }
+            MessagesCacheSettingsDialogMsg::RefreshTopicMessagesCounter => {
+                let connection = self.connection.clone();
+                let topic = self.topic.clone();
+                let topic_name = topic.name.clone();
+                let kafka = KafkaBackend::new(&connection);
+
+                sender.oneshot_command(async move {
+                    let topic = kafka
+                        .topic_message_count(&topic_name, Some(KafkaFetch::Oldest), None, None)
+                        .await;
+                    AsyncCommandOutput::RefreshTopicMessagesCounter(topic)
+                });
+            }
+            MessagesCacheSettingsDialogMsg::CopyToClipboard(text) => {
+                let id = Uuid::new_v4();
+                TOASTER_BROKER.send(AppMsg::ShowToast(id.to_string(), "Copied!".to_string()));
+                self.clipboard.set_contents(text).unwrap_or_else(|err| {
+                    warn!("Unable to store text in clipboard: {}", err);
+                });
+                TOASTER_BROKER.send(AppMsg::HideToast(id.to_string()));
+            }
+            MessagesCacheSettingsDialogMsg::DefaultPageSizeSelected(index) => {
+                self.selected_default_page_size = Some(index as u16);
+            }
+            MessagesCacheSettingsDialogMsg::FetchModeSelected(mode) => {
+                info!("Fetch mode selected: {:?}", mode);
+                self.selected_fetch_mode = Some(mode);
+            }
+            MessagesCacheSettingsDialogMsg::ApplySettings => {
+                info!(
+                    "Applying settings[connection={:?}, topic={:?}]...",
+                    &self.connection, &self.topic
+                );
+                let mut repo = Repository::new();
+                let connection = self.connection.clone();
+                let conn_id = connection.id.unwrap();
+                let topic = self.topic.clone();
+                let topic_name = &topic.name;
+                info!(
+                    "getting updated topic[connection_id={}, topic_name={}]",
+                    &conn_id, &topic_name
+                );
+                let updated_cache = repo.find_topic_cache(conn_id, topic_name);
+                if let Some(cache) = updated_cache.clone() {
+                    debug!("already has cache, asking for confirmation::{:?}", &cache);
+                    self.confirmation_alert.present(&widgets.main_dialog);
+                } else {
+                    sender.input(MessagesCacheSettingsDialogMsg::ConfirmApplySettings);
+                }
+            }
+            MessagesCacheSettingsDialogMsg::ConfirmApplySettings => {
+                let worker = MessagesWorker::new();
+                let connection_id = self.connection.id.unwrap();
+                let topic_name = self.topic.name.clone();
+                info!(
+                    "Confirm settings[connection={:?}, topic={:?}]...",
+                    &connection_id, &topic_name
+                );
+                worker.cleanup_messages(&MessagesCleanupRequest {
+                    connection_id,
+                    topic_name: topic_name.clone(),
+                    refresh: false,
+                });
+                let fetch_value = match self.selected_fetch_mode {
+                    Some(FetchMode::FromTimestamp) => {
+                        let date_text = widgets.formatted_date.text().to_string();
+                        let hours = widgets.time_hours.value_as_int();
+                        let minutes = widgets.time_minutes.value_as_int();
+                        let seconds = widgets.time_seconds.value_as_int();
+                        let date_time_formatted =
+                            format!("{} {:02}:{:02}:{:02}", date_text, hours, minutes, seconds);
+                        let date_time = NaiveDateTime::parse_from_str(
+                            date_time_formatted.as_str(),
+                            DATE_TIME_FORMAT,
+                        );
+                        let now = Local::now();
+                        let offset = now.offset();
+                        let date_time = date_time.unwrap().and_local_timezone(*offset).unwrap();
+                        info!("date_time::{:?}", date_time);
+                        info!("date_time::utc::{}", date_time.timestamp_millis());
+                        Some(date_time.timestamp_millis())
+                    }
+                    Some(FetchMode::Head) => Some(widgets.first_n_messages.value() as i64),
+                    Some(FetchMode::Tail) => Some(widgets.last_n_messages.value() as i64),
+                    _ => None,
+                };
+                let default_page_size = self.selected_default_page_size.unwrap_or_default();
+                let cache = KrustTopicCache {
+                    connection_id,
+                    topic_name: topic_name.clone(),
+                    fetch_mode: self.selected_fetch_mode.unwrap_or_default(),
+                    fetch_value,
+                    default_page_size,
+                    last_updated: Some(Utc::now().timestamp_millis()),
+                };
+                let result = sender.output(MessagesCacheSettingsDialogOutput::Update(cache));
+                match result {
+                    Ok(_) => info!("cache settings output sent!"),
+                    Err(e) => error!("cache settings output error: {:?}", e),
+                }
+                root.close();
+            }
+            MessagesCacheSettingsDialogMsg::Ignore => {
+                info!("Ignore settings...");
+            }
+        };
+
+        self.update_view(widgets, sender);
+    }
+    fn update_cmd_with_view(
+        &mut self,
+        widgets: &mut Self::Widgets,
+        message: Self::CommandOutput,
+        _sender: ComponentSender<Self>,
+        _root: &Self::Root,
+    ) {
+        match message {
+            AsyncCommandOutput::RefreshTopicMessagesCounter(topic) => {
+                widgets
+                    .status_topic_partitions
+                    .set_title(&topic.partitions.len().to_string());
+                widgets
+                    .status_topic_messages_count
+                    .set_title(&topic.total.unwrap_or_default().to_string());
+            }
+        }
+    }
+}

--- a/src/component/messages/messages_tab.rs
+++ b/src/component/messages/messages_tab.rs
@@ -539,7 +539,7 @@ impl FactoryComponent for MessagesTabModel {
             .detach();
         let cache_settings_dialog = MessagesCacheSettingsDialogModel::builder()
             //.transient_for(main_application())
-            .launch((open.connection.clone(), open.topic.clone()))
+            .launch((open.connection.clone(), Some(open.topic.clone())))
             .forward(sender.input_sender(), |msg| match msg {
                 MessagesCacheSettingsDialogOutput::Update(cache) => {
                     MessagesTabMsg::UpdateCacheSettings(cache)

--- a/src/component/messages/messages_tab.rs
+++ b/src/component/messages/messages_tab.rs
@@ -14,13 +14,14 @@ use relm4::{
     typed_view::column::TypedColumnView,
     *,
 };
-use relm4_components::simple_combo_box::SimpleComboBox;
+
+use relm4_components::simple_combo_box::{SimpleComboBox, SimpleComboBoxMsg};
 use tokio_util::sync::CancellationToken;
 use tracing::*;
 use uuid::Uuid;
 
 use crate::backend::kafka::KafkaBackend;
-use crate::backend::repository::MessagesSearchOrder;
+use crate::backend::repository::{KrustTopicCache, MessagesSearchOrder};
 use crate::backend::settings::Settings;
 use crate::backend::worker::MessagesTotalCounterRequest;
 use crate::component::settings_dialog::MessagesSortOrder;
@@ -46,6 +47,10 @@ use crate::{
 use crate::{AppMsg, TOASTER_BROKER};
 
 use super::message_viewer::{MessageViewerModel, MessageViewerMsg};
+use super::messages_cache_settings_dialog::{
+    MessagesCacheSettingsDialogModel, MessagesCacheSettingsDialogMsg,
+    MessagesCacheSettingsDialogOutput,
+};
 use super::messages_send_dialog::MessagesSendDialogMsg;
 use super::{lists::MessageKeyColumn, messages_send_dialog::MessagesSendDialogModel};
 use copypasta::{ClipboardContext, ClipboardProvider};
@@ -79,6 +84,8 @@ pub struct MessagesTabModel {
     add_messages: Controller<MessagesSendDialogModel>,
     clipboard: Box<dyn ClipboardProvider>,
     cache_search_order: Option<MessagesSearchOrder>,
+    cache_settings_dialog: Controller<MessagesCacheSettingsDialogModel>,
+    cache_settings: Option<KrustTopicCache>,
 }
 
 pub struct MessagesTabInit {
@@ -117,6 +124,8 @@ pub enum MessagesTabMsg {
     AddMessages,
     SetCacheOrder(Option<String>, String),
     RefreshTopic,
+    ShowCacheSettings,
+    UpdateCacheSettings(KrustTopicCache),
 }
 
 #[derive(Debug)]
@@ -127,7 +136,7 @@ pub enum CommandMsg {
     MessagesResendResult(String, Option<()>),
 }
 
-const AVAILABLE_PAGE_SIZES: [u16; 7] = [1000, 2000, 5000, 7000, 10000, 20000, 50000];
+pub const AVAILABLE_PAGE_SIZES: [u16; 7] = [1000, 2000, 5000, 7000, 10000, 20000, 50000];
 
 #[relm4::factory(pub)]
 impl FactoryComponent for MessagesTabModel {
@@ -209,14 +218,13 @@ impl FactoryComponent for MessagesTabModel {
                                 sender.input(MessagesTabMsg::AddMessages);
                             },
                         },
-                        #[name(btn_cache_destroy)]
+                        #[name(btn_cache_settings)]
                         gtk::Button {
-                            set_tooltip_text: Some("Destroy cache"),
-                            set_icon_name: "edit-delete-symbolic",
+                            set_tooltip_text: Some("Cache settings"),
+                            set_icon_name: "emblem-system-symbolic",
                             set_margin_start: 5,
-                            add_css_class: "krust-destroy",
                             connect_clicked[sender] => move |_| {
-                                sender.input(MessagesTabMsg::DestroyCache);
+                                sender.input(MessagesTabMsg::ShowCacheSettings);
                             },
                         },
                         #[name(btn_cache_toggle)]
@@ -234,7 +242,18 @@ impl FactoryComponent for MessagesTabModel {
                             set_margin_start: 5,
                             set_label: "",
                             set_visible: false,
-                        }
+                            add_css_class: "cache-timestamp",
+                        },
+                        #[name(btn_cache_destroy)]
+                        gtk::Button {
+                            set_tooltip_text: Some("Destroy cache"),
+                            set_icon_name: "edit-delete-symbolic",
+                            set_margin_start: 5,
+                            add_css_class: "destructive-action",
+                            connect_clicked[sender] => move |_| {
+                                sender.input(MessagesTabMsg::DestroyCache);
+                            },
+                        },
                     },
                     #[wrap(Some)]
                     set_end_widget = &gtk::Box {
@@ -321,7 +340,7 @@ impl FactoryComponent for MessagesTabModel {
                             #[name(total_counter_entry)]
                             gtk::Entry {
                                 set_editable: false,
-                                set_sensitive: false,
+                                set_sensitive: true,
                                 set_margin_start: 5,
                                 set_width_chars: 10,
                             },
@@ -445,7 +464,11 @@ impl FactoryComponent for MessagesTabModel {
 
         // Initialize message viewer
         let message_viewer = MessageViewerModel::builder().launch(()).detach();
-        let default_idx = 0;
+        let cache_settings = open.topic.cached.clone();
+        let default_idx = cache_settings
+            .clone()
+            .map(|c| c.default_page_size as usize)
+            .unwrap_or_default();
         let page_size_combo = SimpleComboBox::builder()
             .launch(SimpleComboBox {
                 variants: AVAILABLE_PAGE_SIZES.to_vec(),
@@ -453,10 +476,11 @@ impl FactoryComponent for MessagesTabModel {
             })
             .forward(sender.input_sender(), MessagesTabMsg::PageSizeChanged);
         page_size_combo.widget().queue_allocate();
+        let fetch_type_default_idx = 0;
         let fetch_type_combo = SimpleComboBox::builder()
             .launch(SimpleComboBox {
                 variants: KafkaFetch::VALUES.to_vec(),
-                active_index: Some(default_idx),
+                active_index: Some(fetch_type_default_idx),
             })
             .forward(sender.input_sender(), MessagesTabMsg::FetchTypeChanged);
 
@@ -513,6 +537,14 @@ impl FactoryComponent for MessagesTabModel {
             //.transient_for(main_application())
             .launch((Some(open.connection.clone()), Some(open.topic.clone())))
             .detach();
+        let cache_settings_dialog = MessagesCacheSettingsDialogModel::builder()
+            //.transient_for(main_application())
+            .launch((open.connection.clone(), open.topic.clone()))
+            .forward(sender.input_sender(), |msg| match msg {
+                MessagesCacheSettingsDialogOutput::Update(cache) => {
+                    MessagesTabMsg::UpdateCacheSettings(cache)
+                }
+            });
         let clipboard = Box::new(ClipboardContext::new().unwrap());
         let model = MessagesTabModel {
             token: CancellationToken::new(),
@@ -522,7 +554,7 @@ impl FactoryComponent for MessagesTabModel {
             messages_wrapper,
             message_viewer,
             page_size_combo,
-            page_size: AVAILABLE_PAGE_SIZES[0],
+            page_size: AVAILABLE_PAGE_SIZES[default_idx],
             fetch_type_combo,
             fetch_type: KafkaFetch::default(),
             max_messages: 1000.0,
@@ -530,6 +562,8 @@ impl FactoryComponent for MessagesTabModel {
             add_messages,
             clipboard,
             cache_search_order: None,
+            cache_settings_dialog,
+            cache_settings,
         };
         let messages_view = &model.messages_wrapper.view;
         let sender_for_selection = sender.clone();
@@ -637,6 +671,14 @@ impl FactoryComponent for MessagesTabModel {
         sender: FactorySender<Self>,
     ) {
         match msg {
+            MessagesTabMsg::UpdateCacheSettings(cache) => {
+                info!("topic cache settings updated! {:?}", cache);
+                self.cache_settings = Some(cache.clone());
+                let cache_settings = cache.clone();
+                let default_idx = cache_settings.default_page_size as usize;
+                self.page_size_combo
+                    .emit(SimpleComboBoxMsg::SetActiveIdx(default_idx));
+            }
             MessagesTabMsg::SetCacheOrder(maybe_column, order) => {
                 let cache_messages_order =
                     maybe_column.map(|column| MessagesSearchOrder { column, order });
@@ -647,6 +689,10 @@ impl FactoryComponent for MessagesTabModel {
             }
             MessagesTabMsg::AddMessages => {
                 self.add_messages.emit(MessagesSendDialogMsg::Show);
+            }
+            MessagesTabMsg::ShowCacheSettings => {
+                self.cache_settings_dialog
+                    .emit(MessagesCacheSettingsDialogMsg::Show);
             }
             MessagesTabMsg::DigitsOnly(value) => {
                 self.max_messages = value;
@@ -660,12 +706,14 @@ impl FactoryComponent for MessagesTabModel {
                     widgets.live_controls.set_visible(false);
                     widgets.btn_cache_refresh.set_visible(true);
                     widgets.btn_cache_destroy.set_visible(true);
+                    widgets.btn_cache_settings.set_visible(true);
                     widgets.pag_total_label.set_text("Total");
                     MessagesMode::Cached { refresh: false }
                 } else {
                     widgets.live_controls.set_visible(true);
                     widgets.btn_cache_refresh.set_visible(false);
                     widgets.btn_cache_destroy.set_visible(false);
+                    widgets.btn_cache_settings.set_visible(false);
                     widgets.pag_total_label.set_text("Messages");
                     widgets.cached_controls.set_visible(false);
                     widgets.cached_centered_controls.set_visible(false);
@@ -680,7 +728,10 @@ impl FactoryComponent for MessagesTabModel {
                 };
                 self.page_size = page_size;
                 self.page_size_combo.widget().queue_allocate();
-                sender.input(MessagesTabMsg::SearchMessages);
+                let cache = self.find_cache();
+                if cache.is_some() {
+                    sender.input(MessagesTabMsg::SearchMessages);
+                }
             }
             MessagesTabMsg::FetchTypeChanged(_idx) => {
                 let fetch_type = match self.fetch_type_combo.model().get_active_elem() {
@@ -769,23 +820,33 @@ impl FactoryComponent for MessagesTabModel {
                 let mut repo = Repository::new();
                 let maybe_topic = repo.find_topic(*conn_id, topic_name);
                 self.topic = maybe_topic.clone().or(Some(*topic));
+                self.cache_settings = self.topic.clone().and_then(|t| t.cached);
                 let toggled = match &maybe_topic {
                     Some(t) => t.cached.is_some(),
                     None => false,
                 };
                 let cache_ts = maybe_topic
                     .and_then(|t| {
-                        t.cached.map(|ts| {
-                            Utc.timestamp_millis_opt(ts)
-                                .unwrap()
-                                .with_timezone(&America::Sao_Paulo)
-                                .format(&timestamp_format)
-                                .to_string()
+                        t.cached.map(|c| {
+                            c.last_updated.map(|ts| {
+                                Utc.timestamp_millis_opt(ts)
+                                    .unwrap()
+                                    .with_timezone(&America::Sao_Paulo)
+                                    .format(&timestamp_format)
+                                    .to_string()
+                            })
                         })
                     })
                     .unwrap_or_default();
-                widgets.cache_timestamp.set_label(&cache_ts);
-                widgets.cache_timestamp.set_visible(true);
+                if cache_ts.clone().is_some() {
+                    widgets.cache_timestamp.set_visible(true);
+                    widgets
+                        .cache_timestamp
+                        .set_label(&cache_ts.unwrap_or_default());
+                } else {
+                    widgets.cache_timestamp.set_visible(false);
+                    widgets.cache_timestamp.set_label("");
+                }
                 widgets.btn_cache_toggle.set_active(toggled);
                 widgets.pag_total_entry.set_text("");
                 widgets.pag_current_entry.set_text("");
@@ -861,6 +922,7 @@ impl FactoryComponent for MessagesTabModel {
                 );
                 TOASTER_BROKER.send(AppMsg::ShowToast(task.id.clone(), "Working...".to_string()));
                 TASK_MANAGER_BROKER.send(TaskManagerMsg::AddTask(task.clone()));
+                let cache = self.cache_settings.clone();
                 sender.oneshot_command(async move {
                     // Run async background task
                     let messages_worker = MessagesWorker::new();
@@ -876,6 +938,7 @@ impl FactoryComponent for MessagesTabModel {
                             search,
                             fetch,
                             max_messages,
+                            cache,
                         })
                         .await
                         .unwrap();
@@ -933,6 +996,7 @@ impl FactoryComponent for MessagesTabModel {
                     MessagesWorker::new().cleanup_messages(&MessagesCleanupRequest {
                         connection_id: conn.id.unwrap(),
                         topic_name: topic.name.clone(),
+                        refresh: false,
                     });
                 info!("destroying cached message::{:?}", result_topic.clone());
                 match result_topic {
@@ -940,6 +1004,7 @@ impl FactoryComponent for MessagesTabModel {
                     None => warn!("unable to destroy cache"),
                 };
                 widgets.cache_timestamp.set_text("");
+                widgets.cache_timestamp.set_visible(false);
                 widgets.btn_cache_toggle.set_active(false);
                 sender.input(MessagesTabMsg::ToggleMode(false));
             }
@@ -952,6 +1017,7 @@ impl FactoryComponent for MessagesTabModel {
                         self.topic = Some(topic.clone());
                         if topic.cached.is_none() {
                             widgets.cache_timestamp.set_text("");
+                            widgets.cache_timestamp.set_visible(false);
                             widgets.btn_cache_toggle.set_active(false);
                             sender.input(MessagesTabMsg::ToggleMode(false));
                         }
@@ -999,6 +1065,7 @@ impl FactoryComponent for MessagesTabModel {
                 let timestamp_formatter = settings.timestamp_formatter();
                 let total = response.total;
                 self.topic = response.topic.clone();
+                self.cache_settings = self.topic.clone().and_then(|t| t.cached);
                 match self.mode {
                     MessagesMode::Live => info!("no need to cleanup list on live mode"),
                     MessagesMode::Cached { refresh: _ } => self.messages_wrapper.clear(),
@@ -1037,20 +1104,26 @@ impl FactoryComponent for MessagesTabModel {
                         .map(|m| MessageListItem::new(m.clone(), timestamp_formatter.clone())),
                 );
                 self.message_viewer.emit(MessageViewerMsg::Clear);
-                let cache_ts = response
-                    .topic
-                    .and_then(|t| {
-                        t.cached.map(|ts| {
-                            Utc.timestamp_millis_opt(ts)
-                                .unwrap()
-                                .with_timezone(&America::Sao_Paulo)
-                                .format(&timestamp_formatter)
-                                .to_string()
-                        })
+                let cache_ts = response.topic.and_then(|t| {
+                    t.cached.map(|c| {
+                        c.last_updated
+                            .map(|ts| {
+                                Utc.timestamp_millis_opt(ts)
+                                    .unwrap()
+                                    .with_timezone(&America::Sao_Paulo)
+                                    .format(&timestamp_formatter)
+                                    .to_string()
+                            })
+                            .unwrap_or_default()
                     })
-                    .unwrap_or(String::default());
-                widgets.cache_timestamp.set_label(&cache_ts);
-                widgets.cache_timestamp.set_visible(true);
+                });
+                if let Some(cache_ts) = cache_ts {
+                    widgets.cache_timestamp.set_label(&cache_ts);
+                    widgets.cache_timestamp.set_visible(true);
+                } else {
+                    widgets.cache_timestamp.set_label("");
+                    widgets.cache_timestamp.set_visible(false);
+                }
                 TOASTER_BROKER.send(AppMsg::HideToast(response.task.clone().unwrap().id.clone()));
                 STATUS_BROKER.send(StatusBarMsg::StopWithInfo {
                     text: Some(format!("{} messages loaded!", self.messages_wrapper.len())),
@@ -1102,6 +1175,20 @@ impl FactoryComponent for MessagesTabModel {
                 TOASTER_BROKER.send(AppMsg::HideToast(id));
             }
         }
+    }
+}
+
+impl MessagesTabModel {
+    fn find_cache(&mut self) -> Option<KrustTopicCache> {
+        let connection_id = self
+            .connection
+            .clone()
+            .expect("should have connection")
+            .id
+            .unwrap();
+        let topic_name = &self.topic.clone().expect("should have a topic").name;
+        let mut repo = Repository::new();
+        repo.find_topic_cache(connection_id, topic_name)
     }
 }
 

--- a/src/component/messages/mod.rs
+++ b/src/component/messages/mod.rs
@@ -1,5 +1,6 @@
 mod lists;
-pub(crate) mod messages_page;
-pub(crate) mod messages_tab;
-pub(crate) mod messages_send_dialog;
 pub(crate) mod message_viewer;
+pub(crate) mod messages_cache_settings_dialog;
+pub(crate) mod messages_page;
+pub(crate) mod messages_send_dialog;
+pub(crate) mod messages_tab;

--- a/src/component/mod.rs
+++ b/src/component/mod.rs
@@ -1,5 +1,9 @@
 //! Relm4 components.
 
+use crate::backend::repository::KrustConnection;
+use adw::TabBar;
+use gtk::prelude::*;
+use tracing::*;
 pub mod app;
 pub mod messages;
 pub mod topics;
@@ -10,3 +14,47 @@ mod connection_page;
 pub(crate) mod settings_dialog;
 mod status_bar;
 pub(crate) mod task_manager;
+
+pub fn get_tab_by_title(tabbar: &TabBar, title: String) -> Option<gtk::Widget> {
+    let tab_revealer: gtk::Revealer = tabbar.first_child().and_downcast().unwrap();
+    let tab_box: gtk::Box = tab_revealer.child().and_downcast().unwrap();
+    let tab_sw: gtk::ScrolledWindow = tab_box.observe_children().item(2).and_downcast().unwrap();
+    let tab_box: gtk::Widget = tab_sw.first_child().and_downcast().unwrap();
+    let mut maybe_tab: Option<gtk::Widget> = None;
+    for i in 0..tab_box.observe_children().n_items() {
+        let tab_gizmo: gtk::Widget = tab_box.observe_children().item(i).and_downcast().unwrap();
+        if tab_gizmo.css_name() == "tabboxchild" {
+            let tab: gtk::Widget = tab_gizmo.first_child().and_downcast().unwrap();
+            if tab.css_name() == "tab" {
+                let ttitle: gtk::Widget = tab.observe_children().item(1).and_downcast().unwrap();
+                let ttitle: gtk::Label = ttitle.first_child().and_downcast().unwrap();
+                let ttitle = ttitle.label();
+                debug!("get_tab_by_title::title={}", ttitle);
+                if ttitle == title {
+                    maybe_tab = Some(tab);
+                }
+            }
+        }
+    }
+    maybe_tab
+}
+
+pub fn colorize_widget_by_connection(conn: &KrustConnection, widget: gtk::Widget) {
+    info!("color_widget_by_connection::{:?}", widget);
+    let css_provider = gtk::CssProvider::new();
+    let color = conn
+        .clone()
+        .color
+        .clone()
+        .unwrap_or("rgb(183, 243, 155)".to_string());
+    let color = color.as_str();
+    let css_class = format!("custom_color_{}", conn.id.unwrap());
+    css_provider.load_from_string(format!(".{} {{ background: {};}}", css_class, color).as_str());
+    let display = widget.display();
+    gtk::style_context_add_provider_for_display(
+        &display,
+        &css_provider,
+        gtk::STYLE_PROVIDER_PRIORITY_APPLICATION,
+    );
+    widget.add_css_class(&css_class);
+}

--- a/src/component/task_manager.rs
+++ b/src/component/task_manager.rs
@@ -383,11 +383,7 @@ impl Component for TaskManagerModel {
                     let progress = &mut item.progress;
                     let mut guard = progress.guard();
                     *guard = step;
-                    trace!(
-                        "task_manager::progress::received::{}={}",
-                        item.value.id,
-                        *guard
-                    );
+
                     if *guard >= 1.0 {
                         sender.input(TaskManagerMsg::RemoveTask(task.clone()));
                     }
@@ -412,7 +408,7 @@ impl Component for TaskManagerModel {
                 }
                 sender.oneshot_command(async move {
                     sleep(Duration::from_secs(2)).await;
-                    trace!("removing task with index: {}", task.id);
+                    debug!("removing task with index: {}", task.id);
                     TaskManagerCommand::RemoveTask(task.clone())
                 });
             }

--- a/src/component/topics/topics_page.rs
+++ b/src/component/topics/topics_page.rs
@@ -18,7 +18,6 @@ relm4::new_action_group!(pub(super) ConnectionTabActionGroup, "connection-tab");
 relm4::new_stateless_action!(pub(super) PinTabAction, ConnectionTabActionGroup, "toggle-pin");
 relm4::new_stateless_action!(pub(super) CloseTabAction, ConnectionTabActionGroup, "close");
 
-#[derive(Debug)]
 pub struct TopicsPageModel {
     pub current: Option<KrustConnection>,
     pub topics: FactoryVecDeque<TopicsTabModel>,
@@ -220,7 +219,8 @@ impl Component for TopicsPageModel {
                         let result = topics.remove(idx);
                         info!(
                             "page model with index {} and name {:?} removed",
-                            idx, result
+                            idx,
+                            result.is_some()
                         );
                     } else {
                         info!("page model not found for removal");

--- a/src/component/topics/topics_page.rs
+++ b/src/component/topics/topics_page.rs
@@ -1,6 +1,9 @@
 use crate::{
     backend::repository::{KrustConnection, KrustTopic},
-    component::topics::topics_tab::{TopicsTabInit, TopicsTabOutput},
+    component::{
+        colorize_widget_by_connection, get_tab_by_title,
+        topics::topics_tab::{TopicsTabInit, TopicsTabOutput},
+    },
 };
 use adw::{prelude::*, TabPage};
 use relm4::{actions::RelmAction, factory::FactoryVecDeque, *};
@@ -178,10 +181,15 @@ impl Component for TopicsPageModel {
             }
             TopicsPageMsg::PageAdded(page, index) => {
                 let tab_model = self.topics.get(index.try_into().unwrap()).unwrap();
+                let conn = tab_model.current.clone().unwrap();
                 let title = tab_model.current.clone().unwrap().name;
                 page.set_title(title.as_str());
                 page.set_live_thumbnail(true);
+                let maybe_tab = get_tab_by_title(&widgets.topics_tabs, title);
 
+                if let Some(tab) = maybe_tab {
+                    colorize_widget_by_connection(&conn, tab);
+                }
                 widgets.topics_viewer.set_selected_page(&page);
             }
             TopicsPageMsg::MenuPagePin => {

--- a/src/component/topics/topics_tab.rs
+++ b/src/component/topics/topics_tab.rs
@@ -436,7 +436,7 @@ impl FactoryComponent for TopicsTabModel {
                                         if let Some(t) = topics_map.get(&topic.name) {
                                             debug!("found topic: {:?}", t);
                                             topic.favourite = t.favourite;
-                                            topic.cached = t.cached;
+                                            topic.cached = t.cached.clone();
                                         }
                                     }
                                     TOASTER_BROKER.send(AppMsg::HideToast(id.to_string()));

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,7 +69,14 @@ fn main() -> Result<(), ()> {
     );
     // Call `gtk::init` manually because we instantiate GTK types in the app model.
     gtk::init().expect("should initialize GTK");
-
+    if let Some(settings) = gtk::Settings::default() {
+        info!(
+            "prefer dark theme?: {}",
+            settings.is_gtk_application_prefer_dark_theme()
+        );
+        //StyleManager::default().set_color_scheme(adw::ColorScheme::ForceDark);
+        //settings.set_gtk_application_prefer_dark_theme(true);
+    };
     info!("starting application: {}", APP_ID);
     initialize_resources();
     gtk::Window::set_default_icon_name(APP_ID);

--- a/src/styles.less
+++ b/src/styles.less
@@ -190,3 +190,9 @@ levelbar block.full {
   border-top-left-radius: 6px;
   border-bottom-left-radius: 6px;
 }
+
+.cache-pill {
+  min-height: 10px;
+  padding-top: 1px;
+  padding-bottom: 1px;
+}

--- a/src/styles.less
+++ b/src/styles.less
@@ -163,3 +163,30 @@ levelbar block.high {
 levelbar block.full {
   animation: attention 1s ease-in-out infinite;
 }
+
+
+.fetch-mode {
+  padding: 0;
+}
+
+.fetch-mode box {
+  margin-right: 0;
+  background-clip: padding-box;
+  border-top-right-radius: 12px;
+  border-bottom-right-radius: 12px;
+  border-top-left-radius: 12px;
+  border-bottom-left-radius: 12px;
+}
+
+.cache-timestamp {
+  background-color: grey;
+  font-weight: 700;
+  min-height: 24px;
+  min-width: 24px;
+  padding: 5px;
+  color: white;
+  border-top-right-radius: 6px;
+  border-bottom-right-radius: 6px;
+  border-top-left-radius: 6px;
+  border-bottom-left-radius: 6px;
+}


### PR DESCRIPTION
  - Resolves #15.
  - Major refactor on messages/topics, adding new table for cache configurations.
  - Connections color coding working!
  - Caching now uses offsets as well messages total to know when it's done processing.
  - Caching fetch modes: All, Head (n oldest messages per partition), Tail (n newest messages per partition) and FromTimestamp.